### PR TITLE
ci: add workflow to auto-update version on main push

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,0 +1,57 @@
+name: Update Version
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_version:
+    name: Update Version
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "18"
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.15.4
+          run_install: true
+      
+      - name: Update version
+        id: version_bumper
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          
+          # Update version in package.json without creating a git tag/commit
+          npm version patch --no-git-tag-version
+          
+          # Extract new version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+          # Update version in app.json
+          # Using node to avoid jq dependency, assuming a simple structure
+          node -e "                                                                                                   
+            const fs = require('fs');
+            const appJsonPath = './app.json';
+            const appJson = require(appJsonPath);
+            appJson.expo.version = '$NEW_VERSION';
+            fs.writeFileSync(appJsonPath, JSON.stringify(appJson, null, 2));
+          "
+      
+      - name: Commit and Push changes
+        run: |
+          git add app.json package.json
+          git commit -m "chore(release): bump version to ${{ steps.version_bumper.outputs.new_version }}"
+          git push


### PR DESCRIPTION
Add GitHub Actions workflow to automatically bump version in package.json and app.json when pushing to main branch

# Pull Request

## Description
Github action workflow to bump app patch version after every push on main.


## Type of Change
- CI/CD changes

## Checklist
<!-- Mark items with "x" when completed -->
- [ ] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings
- [ ] I have added necessary changelog entries
